### PR TITLE
display: Remove COPY_HEADERS usage

### DIFF
--- a/gpu_tonemapper/Android.mk
+++ b/gpu_tonemapper/Android.mk
@@ -2,12 +2,6 @@ LOCAL_PATH := $(call my-dir)
 include $(LOCAL_PATH)/../common.mk
 
 include $(CLEAR_VARS)
-LOCAL_COPY_HEADERS_TO     := $(common_header_export_path)
-LOCAL_COPY_HEADERS        := TonemapFactory.h Tonemapper.h
-LOCAL_VENDOR_MODULE       := true
-include $(BUILD_COPY_HEADERS)
-
-include $(CLEAR_VARS)
 LOCAL_MODULE              := libgpu_tonemapper
 LOCAL_VENDOR_MODULE       := true
 LOCAL_MODULE_TAGS         := optional

--- a/include/Android.mk
+++ b/include/Android.mk
@@ -1,19 +1,3 @@
-LOCAL_PATH:= $(call my-dir)
-include $(LOCAL_PATH)/../common.mk
-include $(CLEAR_VARS)
-
 # Legacy header copy. This is deprecated.
 # Modules using these headers should shift to using
 # LOCAL_HEADER_LIBRARIES := display_headers
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
-LOCAL_COPY_HEADERS            := display_color_processing.h \
-                                 display_properties.h \
-                                 ../libqdutils/qd_utils.h \
-                                 ../libqdutils/display_config.h \
-                                 ../libqservice/QServiceUtils.h \
-                                 ../libqservice/IQService.h \
-                                 ../libqservice/IQHDMIClient.h \
-                                 ../libqservice/IQClient.h
-
-include $(BUILD_COPY_HEADERS)

--- a/libcopybit/Android.mk
+++ b/libcopybit/Android.mk
@@ -11,13 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-LOCAL_PATH:= $(call my-dir)
-include $(LOCAL_PATH)/../common.mk
-include $(CLEAR_VARS)
-
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
-LOCAL_COPY_HEADERS            := copybit.h copybit_priv.h c2d2.h
-#Copy the headers regardless of whether copybit is built
-include $(BUILD_COPY_HEADERS)

--- a/libdebug/Android.mk
+++ b/libdebug/Android.mk
@@ -8,7 +8,6 @@ LOCAL_SHARED_LIBRARIES        := libdl
 LOCAL_CFLAGS                  := -DLOG_TAG=\"SDM\" -Wall -Werror -fno-operator-names
 LOCAL_CLANG                   := true
 LOCAL_SRC_FILES               := debug_handler.cpp
-LOCAL_COPY_HEADERS_TO         := qcom/display
-LOCAL_COPY_HEADERS            := debug_handler.h
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
 include $(BUILD_SHARED_LIBRARY)

--- a/libdrmutils/Android.mk
+++ b/libdrmutils/Android.mk
@@ -12,7 +12,6 @@ LOCAL_CFLAGS                  := -DLOG_TAG=\"DRMUTILS\" -Wall  -Werror -fno-oper
 LOCAL_CLANG                   := true
 LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
 LOCAL_SRC_FILES               := drm_master.cpp drm_res_mgr.cpp drm_lib_loader.cpp
-LOCAL_COPY_HEADERS_TO         := qcom/display
-LOCAL_COPY_HEADERS            := drm_master.h drm_res_mgr.h drm_lib_loader.h drm_logger.h drm_interface.h
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 
 include $(BUILD_SHARED_LIBRARY)

--- a/sdm/libs/core/Android.mk
+++ b/sdm/libs/core/Android.mk
@@ -61,31 +61,3 @@ ifneq ($(TARGET_IS_HEADLESS), true)
 endif
 
 include $(BUILD_SHARED_LIBRARY)
-
-SDM_HEADER_PATH := ../../include
-include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)/sdm/core
-LOCAL_COPY_HEADERS             = $(SDM_HEADER_PATH)/core/buffer_allocator.h \
-                                 $(SDM_HEADER_PATH)/core/buffer_sync_handler.h \
-                                 $(SDM_HEADER_PATH)/core/core_interface.h \
-                                 $(SDM_HEADER_PATH)/core/display_interface.h \
-                                 $(SDM_HEADER_PATH)/core/layer_buffer.h \
-                                 $(SDM_HEADER_PATH)/core/layer_stack.h \
-                                 $(SDM_HEADER_PATH)/core/sdm_types.h \
-                                 $(SDM_HEADER_PATH)/core/socket_handler.h \
-                                 $(SDM_HEADER_PATH)/core/dpps_interface.h
-include $(BUILD_COPY_HEADERS)
-
-include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)/sdm/private
-LOCAL_COPY_HEADERS             = $(SDM_HEADER_PATH)/private/color_interface.h \
-                                 $(SDM_HEADER_PATH)/private/color_params.h \
-                                 $(SDM_HEADER_PATH)/private/extension_interface.h \
-                                 $(SDM_HEADER_PATH)/private/hw_info_types.h \
-                                 $(SDM_HEADER_PATH)/private/partial_update_interface.h \
-                                 $(SDM_HEADER_PATH)/private/resource_interface.h \
-                                 $(SDM_HEADER_PATH)/private/strategy_interface.h \
-                                 $(SDM_HEADER_PATH)/private/dpps_control_interface.h
-include $(BUILD_COPY_HEADERS)

--- a/sdm/libs/utils/Android.mk
+++ b/sdm/libs/utils/Android.mk
@@ -16,19 +16,3 @@ LOCAL_SRC_FILES               := debug.cpp \
 
 LOCAL_SHARED_LIBRARIES        := libdisplaydebug
 include $(BUILD_SHARED_LIBRARY)
-
-SDM_HEADER_PATH := ../../include
-include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)/sdm/utils
-LOCAL_COPY_HEADERS             = $(SDM_HEADER_PATH)/utils/constants.h \
-                                 $(SDM_HEADER_PATH)/utils/debug.h \
-                                 $(SDM_HEADER_PATH)/utils/formats.h \
-                                 $(SDM_HEADER_PATH)/utils/locker.h \
-                                 $(SDM_HEADER_PATH)/utils/rect.h \
-                                 $(SDM_HEADER_PATH)/utils/sys.h \
-                                 $(SDM_HEADER_PATH)/utils/sync_task.h \
-                                 $(SDM_HEADER_PATH)/utils/utils.h \
-                                 $(SDM_HEADER_PATH)/utils/factory.h
-
-include $(BUILD_COPY_HEADERS)


### PR DESCRIPTION
Fix building error: "LOCAL_COPY_HEADERS is obsolete."

Change-Id: I964a11f036e03fb9fa2dec05a1698c118b06b421