### PR TITLE
display: Drop LOCAL_COPY_HEADERS usage

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -68,29 +68,6 @@ ifeq ($(TARGET_USES_GRALLOC1), true)
     common_flags += -DUSE_GRALLOC1
 endif
 
-common_includes := system/core/base/include
-CHECK_VERSION_LE = $(shell if [ $(1) -le $(2) ] ; then echo true ; else echo false ; fi)
-PLATFORM_SDK_NOUGAT = 25
-ifeq "REL" "$(PLATFORM_VERSION_CODENAME)"
-ifeq ($(call CHECK_VERSION_LE, $(PLATFORM_SDK_VERSION), $(PLATFORM_SDK_NOUGAT)), true)
-version_flag := -D__NOUGAT__
-
-# These include paths are deprecated post N
-common_includes += $(display_top)/libqdutils
-common_includes += $(display_top)/libqservice
-common_includes += $(display_top)/gpu_tonemapper
-ifneq ($(TARGET_IS_HEADLESS), true)
-    common_includes += $(display_top)/libcopybit
-endif
-
-common_includes += $(display_top)/include
-common_includes += $(display_top)/sdm/include
-common_flags += -isystem $(TARGET_OUT_HEADERS)/qcom/display
-endif
-endif
-
-common_header_export_path := qcom/display
-
 #Common libraries external to display HAL
 common_libs := liblog libutils libcutils libhardware
 common_deps  :=

--- a/gpu_tonemapper/Android.mk
+++ b/gpu_tonemapper/Android.mk
@@ -2,16 +2,10 @@ LOCAL_PATH := $(call my-dir)
 include $(LOCAL_PATH)/../common.mk
 
 include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE       := true
-LOCAL_COPY_HEADERS_TO     := $(common_header_export_path)
-LOCAL_COPY_HEADERS        := TonemapFactory.h Tonemapper.h
-include $(BUILD_COPY_HEADERS)
-
-include $(CLEAR_VARS)
 LOCAL_MODULE              := libgpu_tonemapper
 LOCAL_VENDOR_MODULE       := true
 LOCAL_MODULE_TAGS         := optional
-LOCAL_C_INCLUDES          := $(TARGET_OUT_HEADERS)/qcom/display/
+LOCAL_HEADER_LIBRARIES    := display_headers
 LOCAL_C_INCLUDES          += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_SHARED_LIBRARIES    := libEGL libGLESv2 libGLESv3 libui libutils liblog
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps) $(kernel_deps)

--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -36,8 +36,6 @@ LOCAL_SRC_FILES               := gr_ion_alloc.cpp \
                                  gr_allocator.cpp \
                                  gr_buf_mgr.cpp \
                                  gr_device_impl.cpp
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
-LOCAL_COPY_HEADERS            := gr_device_impl.h gralloc_priv.h gr_priv_handle.h
 
 ifeq ($(call is-board-platform-in-list, msm8909), true)
     LOCAL_CFLAGS += -DUSE_SECURE_HEAP

--- a/include/Android.mk
+++ b/include/Android.mk
@@ -1,20 +1,3 @@
 LOCAL_PATH:= $(call my-dir)
 include $(LOCAL_PATH)/../common.mk
 include $(CLEAR_VARS)
-
-# Legacy header copy. This is deprecated.
-# Modules using these headers should shift to using
-# LOCAL_HEADER_LIBRARIES := display_headers
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
-LOCAL_COPY_HEADERS            := color_metadata.h \
-                                 display_properties.h \
-                                 ../libqdutils/qd_utils.h \
-                                 ../libqdutils/qdMetaData.h \
-                                 ../libqdutils/display_config.h \
-                                 ../libqservice/QServiceUtils.h \
-                                 ../libqservice/IQService.h \
-                                 ../libqservice/IQHDMIClient.h \
-                                 ../libqservice/IQClient.h
-
-include $(BUILD_COPY_HEADERS)

--- a/libcopybit/Android.mk
+++ b/libcopybit/Android.mk
@@ -16,12 +16,6 @@ LOCAL_PATH:= $(call my-dir)
 include $(LOCAL_PATH)/../common.mk
 include $(CLEAR_VARS)
 
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
-LOCAL_COPY_HEADERS            := copybit.h copybit_priv.h c2d2.h
-#Copy the headers regardless of whether copybit is built
-include $(BUILD_COPY_HEADERS)
-
 include $(CLEAR_VARS)
 ifneq ($(TARGET_USES_GRALLOC1), true)
 LOCAL_MODULE                  := copybit.$(TARGET_BOARD_PLATFORM)

--- a/libdrmutils/Android.mk
+++ b/libdrmutils/Android.mk
@@ -11,7 +11,5 @@ LOCAL_CFLAGS                  := -DLOG_TAG=\"DRMUTILS\" -Wall -std=c++11 -Werror
 LOCAL_CLANG                   := true
 LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
 LOCAL_SRC_FILES               := drm_master.cpp drm_res_mgr.cpp drm_lib_loader.cpp
-LOCAL_COPY_HEADERS_TO         := qcom/display
-LOCAL_COPY_HEADERS            := drm_master.h drm_res_mgr.h drm_lib_loader.h drm_logger.h drm_interface.h
 
 include $(BUILD_SHARED_LIBRARY)

--- a/sdm/libs/core/Android.mk
+++ b/sdm/libs/core/Android.mk
@@ -62,31 +62,3 @@ ifneq ($(TARGET_IS_HEADLESS), true)
 endif
 
 include $(BUILD_SHARED_LIBRARY)
-
-SDM_HEADER_PATH := ../../include
-include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)/sdm/core
-LOCAL_COPY_HEADERS             = $(SDM_HEADER_PATH)/core/buffer_allocator.h \
-                                 $(SDM_HEADER_PATH)/core/buffer_sync_handler.h \
-                                 $(SDM_HEADER_PATH)/core/core_interface.h \
-                                 $(SDM_HEADER_PATH)/core/debug_interface.h \
-                                 $(SDM_HEADER_PATH)/core/display_interface.h \
-                                 $(SDM_HEADER_PATH)/core/layer_buffer.h \
-                                 $(SDM_HEADER_PATH)/core/layer_stack.h \
-                                 $(SDM_HEADER_PATH)/core/sdm_types.h \
-                                 $(SDM_HEADER_PATH)/core/socket_handler.h
-include $(BUILD_COPY_HEADERS)
-
-include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)/sdm/private
-LOCAL_COPY_HEADERS             = $(SDM_HEADER_PATH)/private/color_interface.h \
-                                 $(SDM_HEADER_PATH)/private/color_params.h \
-                                 $(SDM_HEADER_PATH)/private/extension_interface.h \
-                                 $(SDM_HEADER_PATH)/private/hw_info_types.h \
-                                 $(SDM_HEADER_PATH)/private/partial_update_interface.h \
-                                 $(SDM_HEADER_PATH)/private/resource_interface.h \
-                                 $(SDM_HEADER_PATH)/private/strategy_interface.h \
-                                 $(SDM_HEADER_PATH)/private/dpps_control_interface.h
-include $(BUILD_COPY_HEADERS)

--- a/sdm/libs/utils/Android.mk
+++ b/sdm/libs/utils/Android.mk
@@ -15,19 +15,3 @@ LOCAL_SRC_FILES               := debug.cpp \
                                  utils.cpp
 
 include $(BUILD_SHARED_LIBRARY)
-
-SDM_HEADER_PATH := ../../include
-include $(CLEAR_VARS)
-LOCAL_VENDOR_MODULE           := true
-LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)/sdm/utils
-LOCAL_COPY_HEADERS             = $(SDM_HEADER_PATH)/utils/constants.h \
-                                 $(SDM_HEADER_PATH)/utils/debug.h \
-                                 $(SDM_HEADER_PATH)/utils/formats.h \
-                                 $(SDM_HEADER_PATH)/utils/locker.h \
-                                 $(SDM_HEADER_PATH)/utils/rect.h \
-                                 $(SDM_HEADER_PATH)/utils/sys.h \
-                                 $(SDM_HEADER_PATH)/utils/sync_task.h \
-                                 $(SDM_HEADER_PATH)/utils/utils.h \
-                                 $(SDM_HEADER_PATH)/utils/factory.h
-
-include $(BUILD_COPY_HEADERS)


### PR DESCRIPTION
LOCAL_COPY_HEADERS is deprecated, so remove all its usages
to avoid build warnings.

Change-Id: I964a11f036e03fb9fa2dec05a1698c118b06b421