### PR TITLE
gralloc: Conditionally revert changes related to gralloc struct

### DIFF
--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -36,7 +36,10 @@ cc_library_shared {
 //libgralloccore
 cc_library_shared {
     name: "libgralloccore",
-    defaults: ["qtidisplay_defaults"],
+    defaults: [
+        "qtidisplay_defaults",
+        "gralloc_handle_has_reserved_size_defaults",
+    ],
     sanitize: {
         integer_overflow: true,
     },

--- a/gralloc/gr_buf_mgr.cpp
+++ b/gralloc/gr_buf_mgr.cpp
@@ -103,14 +103,15 @@ static uint64_t getMetaDataSize(uint64_t reserved_region_size) {
   return static_cast<uint64_t>(ROUND_UP_PAGESIZE(sizeof(MetaData_t) + reserved_region_size));
 }
 
-static void unmapAndReset(private_handle_t *handle, uint64_t reserved_region_size = 0) {
+static void unmapAndReset(private_handle_t *handle) {
+  uint64_t reserved_region_size = handle->reserved_size;
   if (private_handle_t::validate(handle) == 0 && handle->base_metadata) {
     munmap(reinterpret_cast<void *>(handle->base_metadata), getMetaDataSize(reserved_region_size));
     handle->base_metadata = 0;
   }
 }
 
-static int validateAndMap(private_handle_t *handle, uint64_t reserved_region_size = 0) {
+static int validateAndMap(private_handle_t *handle) {
   if (private_handle_t::validate(handle)) {
     ALOGE("%s: Private handle is invalid - handle:%p", __func__, handle);
     return -1;
@@ -121,6 +122,7 @@ static int validateAndMap(private_handle_t *handle, uint64_t reserved_region_siz
   }
 
   if (!handle->base_metadata) {
+    uint64_t reserved_region_size = handle->reserved_size;
     uint64_t size = getMetaDataSize(reserved_region_size);
     void *base = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, handle->fd_metadata, 0);
     if (base == reinterpret_cast<void *>(MAP_FAILED)) {
@@ -129,23 +131,6 @@ static int validateAndMap(private_handle_t *handle, uint64_t reserved_region_siz
       return -1;
     }
     handle->base_metadata = (uintptr_t)base;
-#ifdef METADATA_V2
-    // The allocator process gets the reserved region size from the BufferDescriptor.
-    // When importing to another process, the reserved size is unknown until mapping the metadata,
-    // hence the re-mapping below
-    auto metadata = reinterpret_cast<MetaData_t *>(handle->base_metadata);
-    if (reserved_region_size == 0 && metadata->reservedSize) {
-      size = getMetaDataSize(metadata->reservedSize);
-      unmapAndReset(handle);
-      void *new_base = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, handle->fd_metadata, 0);
-      if (new_base == reinterpret_cast<void *>(MAP_FAILED)) {
-        ALOGE("%s: metadata mmap failed - handle:%p fd: %d err: %s", __func__, handle,
-              handle->fd_metadata, strerror(errno));
-        return -1;
-      }
-      handle->base_metadata = (uintptr_t)new_base;
-    }
-#endif
   }
   return 0;
 }
@@ -764,7 +749,7 @@ Error BufferManager::FreeBuffer(std::shared_ptr<Buffer> buf) {
     return Error::BAD_BUFFER;
   }
 
-  auto meta_size = getMetaDataSize(buf->reserved_size);
+  auto meta_size = getMetaDataSize(hnd->reserved_size);
 
   if (allocator_->FreeBuffer(reinterpret_cast<void *>(hnd->base), hnd->size, hnd->offset, hnd->fd,
                              buf->ion_handle_main) != 0) {
@@ -1137,6 +1122,7 @@ Error BufferManager::AllocateBuffer(const BufferDescriptor &descriptor, buffer_h
                           descriptor.GetWidth(), descriptor.GetHeight(), format, buffer_type,
                           data.size, usage);
 
+  hnd->reserved_size = static_cast<unsigned int>(descriptor.GetReservedSize());
   hnd->id = ++next_id_;
   hnd->base = 0;
   hnd->base_metadata = 0;
@@ -1147,11 +1133,7 @@ Error BufferManager::AllocateBuffer(const BufferDescriptor &descriptor, buffer_h
     setMetaDataAndUnmap(hnd, SET_GRAPHICS_METADATA, reinterpret_cast<void *>(&graphics_metadata));
   }
 
-#ifdef METADATA_V2
-  auto error = validateAndMap(hnd, descriptor.GetReservedSize());
-#else
   auto error = validateAndMap(hnd);
-#endif
 
   if (error != 0) {
     ALOGE("validateAndMap failed");
@@ -1173,7 +1155,7 @@ Error BufferManager::AllocateBuffer(const BufferDescriptor &descriptor, buffer_h
   metadata->crop.right = hnd->width;
   metadata->crop.bottom = hnd->height;
 
-  unmapAndReset(hnd, descriptor.GetReservedSize());
+  unmapAndReset(hnd);
 
   *handle = hnd;
 


### PR DESCRIPTION
Revert this commit if gralloc struct does not have reserved_size field.

This conditionally reverts: "gralloc: Fix issue with mmap/munmap meta
due to reserved size", which relies on changes to the gralloc struct
in commit 34fef9c4f6e22d97c52ff60ccd93fc404ea6a4cb.

Change-Id: I7cfae76bfe8c999f4bbf3e03f2362b3c0e21e46d